### PR TITLE
Refine work-history wording and add contest platform badges

### DIFF
--- a/_posts/2023-07-26-contest.md
+++ b/_posts/2023-07-26-contest.md
@@ -2,6 +2,7 @@
 layout: post
 title: "Machine Learning Contest @ CodaLab"
 category: contest
+platform: CodaLab
 date: 2023-7-26
 description: '<a href="http://algonauts.csail.mit.edu/challenge.html">Alogonauts Project 2023 Challenge</a><br />
       Ranked <b>8th</b> out of 107 teams.<br />'

--- a/_posts/2024-04-17-contest.md
+++ b/_posts/2024-04-17-contest.md
@@ -2,6 +2,7 @@
 layout: post
 title: "Machine Learning Contest @ Kaggle"
 category: contest
+platform: Kaggle
 date: 2024-4-17
 description: '<a href="https://www.kaggle.com/competitions/llm-prompt-recovery">LLM Prompt Recovery</a><br />
       Ranked <b>85th</b> out of 2175 teams.🥈<br />'

--- a/en/index.html
+++ b/en/index.html
@@ -124,6 +124,9 @@ keywords: Takuya Matsuyama, 松山 卓矢, web engineer, Webエンジニア, Fuk
       {% for post in site.posts %}
       {% if post.category == "contest" %}
       <div class="contest_block">
+        {% if post.platform %}
+        <span class="category-badge">{{ post.platform }}</span>
+        {% endif %}
         {% if post.description %}
         <p> {{ post.description }} </p>
         {% endif %}
@@ -173,18 +176,17 @@ keywords: Takuya Matsuyama, 松山 卓矢, web engineer, Webエンジニア, Fuk
   <div class="education">
     <p><i>2025 April - </i><br />
       <b><a href="https://www.fukuicompu.co.jp/">Fukui Computer Co., Ltd.</a></b><br />
-      Web Engineer (Full-stack) <br />
-      ASP.NET Core, TypeScript, SQL Server, Azure
+      Web Engineer (Full-stack)
     </p>
 
     <p><i>2024 July - 2025 February </i><br />
       <b><a href="https://www.nii.ac.jp/en/">National Institute of Informatics (NII)</a></b><br />
-      Research Assistant in LLMC
+      Research Assistant in LLM Center
     </p>
 
     <p><i>2023 April - 2025 March </i><br />
       <b><a href="https://www.nict.go.jp/en/">National Institute of Information and Communications Technology (NICT)</a></b><br />
-      Collaborating Researcher in CiNet
+      Collaborating Researcher
     </p>
 
     <p><i>2023 August - 2023 September (1 month)</i><br />

--- a/index.html
+++ b/index.html
@@ -125,6 +125,9 @@ lang: ja
       {% for post in site.posts %}
       {% if post.category == "contest" %}
       <div class="contest_block">
+        {% if post.platform %}
+        <span class="category-badge">{{ post.platform }}</span>
+        {% endif %}
         {% if post.description %}
         <p> {{ post.description }} </p>
         {% endif %}
@@ -174,23 +177,22 @@ lang: ja
   <div class="education">
     <p><i>2025/4 - </i><br />
       <b><a href="https://www.fukuicompu.co.jp/">福井コンピュータ株式会社</a></b><br />
-      Webエンジニア（フルスタック）<br />
-      ASP.NET Core, TypeScript, SQL Server, Azure
+      Webエンジニア（フルスタック）
     </p>
 
     <p><i>2024/7 - 2025/2 </i><br />
       <b><a href="https://www.nii.ac.jp/">国立情報学研究所（NII）</a></b><br />
-      LLMC リサーチアシスタント
+      LLMセンター リサーチアシスタント
     </p>
 
     <p><i>2023/4 - 2025/3 </i><br />
       <b><a href="https://www.nict.go.jp/">情報通信研究機構（NICT）</a></b><br />
-      CiNet 連携研究員
+      協力研究員
     </p>
 
     <p><i>2023/8 - 2023/9（1ヶ月）</i><br />
-      <b><a href="https://group.ntt/jp/">NTT研究所</a></b><br />
-      研究インターンシップ <br />
+      <b><a href="https://group.ntt/jp/">NTT R&amp;D</a></b><br />
+      リサーチインターンシップ <br />
       生成AIを用いたEEGからの画像生成
     </p>
     <div class="block-veil"></div>


### PR DESCRIPTION
Follow-up tweaks to both the Japanese (root) and English (`/en`) pages.

## Work history (職歴 / Work Experience)
| Entry | Change |
|---|---|
| Fukui Computer | Removed the tech-stack line (`ASP.NET Core, TypeScript, SQL Server, Azure`) |
| NII | `LLMC` → **LLMセンター** / **LLM Center** |
| NICT | Dropped the `CiNet` qualifier; **連携研究員 → 協力研究員** (EN: "Collaborating Researcher") |
| NTT | **NTT研究所 → NTT R&D**; **研究インターンシップ → リサーチインターンシップ** (EN already "NTT R&D / Research Internship") |

## Contest badges
Added a `platform` field to each contest post and rendered it as a `category-badge` (same style as the Publication/Conference badges), so the competition platform is obvious:
- **LLM Prompt Recovery → Kaggle** badge
- **Algonauts Project 2023 → CodaLab** badge

## Verification
Rebuilt with Jekyll and screenshotted both pages with headless Chrome — badges show on the contest cards and the work-history entries read as intended on both the Japanese root and `/en`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KYQuMLW3a1qQiZU5E17m7t)_