### PR TITLE
Move LLM Center to the NII institution line and link it

### DIFF
--- a/en/index.html
+++ b/en/index.html
@@ -180,8 +180,8 @@ keywords: Takuya Matsuyama, 松山 卓矢, web engineer, Webエンジニア, Fuk
     </p>
 
     <p><i>2024 July - 2025 February </i><br />
-      <b><a href="https://www.nii.ac.jp/en/">National Institute of Informatics (NII)</a></b><br />
-      Research Assistant in LLM Center
+      <b><a href="https://llmc.nii.ac.jp/en/">National Institute of Informatics (NII) LLM Center</a></b><br />
+      Research Assistant
     </p>
 
     <p><i>2023 April - 2025 March </i><br />

--- a/index.html
+++ b/index.html
@@ -181,8 +181,8 @@ lang: ja
     </p>
 
     <p><i>2024/7 - 2025/2 </i><br />
-      <b><a href="https://www.nii.ac.jp/">国立情報学研究所（NII）</a></b><br />
-      LLMセンター リサーチアシスタント
+      <b><a href="https://llmc.nii.ac.jp/">国立情報学研究所（NII） LLMセンター</a></b><br />
+      リサーチアシスタント
     </p>
 
     <p><i>2023/4 - 2025/3 </i><br />


### PR DESCRIPTION
Restructures the NII entry in the work history on both pages so that the LLM Center sits on the institution (top) line with the role beneath it.

| | Before | After |
|---|---|---|
| **JA** top | 国立情報学研究所（NII） *(→ nii.ac.jp)* | **国立情報学研究所（NII） LLMセンター** *(→ llmc.nii.ac.jp)* |
| **JA** bottom | LLMセンター リサーチアシスタント | リサーチアシスタント |
| **EN** top | National Institute of Informatics (NII) *(→ nii.ac.jp/en)* | **National Institute of Informatics (NII) LLM Center** *(→ llmc.nii.ac.jp/en)* |
| **EN** bottom | Research Assistant in LLM Center | Research Assistant |

The top-line link now points to the NII **Research and Development Center for Large Language Models (LLMC)**:
- JA: https://llmc.nii.ac.jp/
- EN: https://llmc.nii.ac.jp/en/

## Verification
Rebuilt with Jekyll and screenshotted both the Japanese root and `/en` — the NII entry shows the center on the institution line (linked) and "Research Assistant / リサーチアシスタント" below.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KYQuMLW3a1qQiZU5E17m7t)_